### PR TITLE
When signer thread is created in rsksiInitModule thread successful

### DIFF
--- a/runtime/lib_ksils12.h
+++ b/runtime/lib_ksils12.h
@@ -49,6 +49,25 @@ typedef enum LOGSIG_SyncMode_en {
 	LOGSIG_SYNCHRONOUS = 0x01
 } LOGSIG_SyncMode;
 
+enum {
+	/* Signer state assigned before the signer thread is initialized. State remains
+	 * until thread initialization begins. In case of system failure to create new
+	 * thread state remains the same.
+	 */
+	SIGNER_IDLE = 0x01,
+
+	/* Signer state assigned while signer thread initialization is in progress.
+	 */
+	SIGNER_INIT = 0x02,
+
+	/* Signer state assigned when signer thread is initialized and ready to work.
+	 */
+	SIGNER_STARTED = 0x04,
+
+	/* Thread state assigned when signer thread is being closed (signer thread returns).
+	 */
+	SIGNER_STOPPED = 0x08
+};
 
 /* Max number of roots inside the forest. This permits blocks of up to
  * 2^MAX_ROOTS records. We assume that 64 is sufficient for all use
@@ -90,7 +109,7 @@ struct rsksictx_s {
 	pthread_mutex_t module_lock;
 	pthread_t signer_thread;
 	ProtectedQueue *signer_queue;
-	bool thread_started;
+	int signer_state;
 	uint8_t disabled;	/* permits to disable the plugin --> set to 1 */
 
 	ksifile *ksi;		/* List of signature files for keeping track of block timeouts. */


### PR DESCRIPTION
initialization is verified before returning the function. This will
prevent adding records to not initialized module and in case of an
error signature files opened will contain only magic bytes.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
