### PR TITLE
ksi bugfix: Optimized code in KSI module initialization fixed.

### DIFF
--- a/runtime/lib_ksils12.c
+++ b/runtime/lib_ksils12.c
@@ -834,7 +834,7 @@ create_signer_thread(rsksictx ctx) {
 		}
 
 		/* Lock until init. */
-		while(ctx->signer_state & SIGNER_INIT);
+		while(*((volatile int*)&ctx->signer_state) & SIGNER_INIT);
 
 		if (ctx->signer_state != SIGNER_STARTED) {
 			return RSGTE_INTERNAL;


### PR DESCRIPTION
KSI module initialization will not stuck in infinite loop when code is
built with optimization -O2.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
