### PR TITLE
ksi bugfix: possible crash fixed when several log files are opened.

### DIFF
--- a/runtime/lib_ksils12.h
+++ b/runtime/lib_ksils12.h
@@ -90,6 +90,8 @@ struct rsksictx_s {
 	KSI_HashAlgorithm hmacAlg;
 	uint8_t bKeepRecordHashes;
 	uint8_t bKeepTreeHashes;
+	uint64_t confInterval;
+	time_t tConfRequested;
 	uint64_t blockLevelLimit;
 	uint32_t blockTimeLimit;
 	uint32_t effectiveBlockLevelLimit; /* level limit adjusted by gateway settings */
@@ -201,6 +203,7 @@ struct rsksistatefile {
 #define getIVLenKSI(bh) (hashOutputLengthOctetsKSI((bh)->hashID))
 #define rsksiSetBlockLevelLimit(ctx, limit) ((ctx)->blockLevelLimit = (ctx)->effectiveBlockLevelLimit = limit)
 #define rsksiSetBlockTimeLimit(ctx, limit) ((ctx)->blockTimeLimit = limit)
+#define rsksiSetConfInterval(ctx, val) ((ctx)->confInterval = val)
 #define rsksiSetKeepRecordHashes(ctx, val) ((ctx)->bKeepRecordHashes = val)
 #define rsksiSetKeepTreeHashes(ctx, val) ((ctx)->bKeepTreeHashes = val)
 #define rsksiSetFileFormat(ctx, val) ((ctx)->fileFormat = val)

--- a/runtime/lmsig_ksi-ls12.c
+++ b/runtime/lmsig_ksi-ls12.c
@@ -49,6 +49,7 @@ static struct cnfparamdescr cnfpdescr[] = {
 	{ "sig.aggregator.hmacAlg", eCmdHdlrGetWord, 0 },
 	{ "sig.block.levelLimit", eCmdHdlrSize, CNFPARAM_REQUIRED},
 	{ "sig.block.timeLimit", eCmdHdlrInt, 0},
+	{ "sig.confinterval", eCmdHdlrInt, 0},
 	{ "sig.keeprecordhashes", eCmdHdlrBinary, 0 },
 	{ "sig.keeptreehashes", eCmdHdlrBinary, 0},
 	{ "sig.fileformat", eCmdHdlrString, 0},
@@ -167,6 +168,14 @@ SetCnfParam(void *pT, struct nvlst *lst)
 				pThis->ctx->disabled = true;
 			} else {
 				rsksiSetBlockTimeLimit(pThis->ctx, pvals[i].val.d.n);
+			}
+		} else if (!strcmp(pblk.descr[i].name, "sig.confinterval")) {
+			if (pvals[i].val.d.n < 0) {
+				LogError(0, RS_RET_ERR, "sig.confinterval "
+					"%llu invalid - signing disabled", pvals[i].val.d.n);
+				pThis->ctx->disabled = true;
+			} else {
+				rsksiSetConfInterval(pThis->ctx, pvals[i].val.d.n);
 			}
 		} else if (!strcmp(pblk.descr[i].name, "sig.keeprecordhashes")) {
 			rsksiSetKeepRecordHashes(pThis->ctx, pvals[i].val.d.n);


### PR DESCRIPTION
KSI module in async mode used to request aggregator conf. every time a log
file was opened. When several log files were opened simultaneously
corresponding amount of pointless concurrent conf. requests were posted.
Concurrent conf. requests lead to a bug in libksi, where internal count of
pending requests was not decremented correctly causing system to crash.

Fix for the issue is to optimize the frequency of conf. requests so that only
one conf. requests is handled at once. Instead of checking conf. every time
log file is opened, conf is requested periodically after conf timeout. This will
affect both sync and async mode.

New option for KSI module introduced - sig.confinterval="time, s".

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
